### PR TITLE
Wrap SSPI code in conditional checks

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -39,7 +39,9 @@ struct auth_s *new_auth(void) {
 	memset(tmp->passntlm2, 0, MINIBUF_SIZE);
 	memset(tmp->passnt, 0, MINIBUF_SIZE);
 	memset(tmp->passlm, 0, MINIBUF_SIZE);
+#ifdef __CYGWIN__	
 	memset(&tmp->sspi, 0, sizeof(struct sspi_handle));
+#endif
 	tmp->hashntlm2 = 1;
 	tmp->hashnt = 0;
 	tmp->hashlm = 0;

--- a/auth.h
+++ b/auth.h
@@ -25,7 +25,9 @@
 #include <stdint.h>
 
 #include "utils.h"
+#ifdef __CYGWIN__
 #include "sspi.h"
+#endif
 
 /*
  * Although I always prefer structs with pointer refs, I need direct storage
@@ -42,7 +44,9 @@ struct auth_s {
 	int hashntlm2;
 	int hashnt;
 	int hashlm;
+#ifdef __CYGWIN__
 	struct sspi_handle sspi;
+#endif
 	uint32_t flags;
 };
 


### PR DESCRIPTION
SSPI code is conditionally compiled only if `__CYGWIN__` is defined. The auth module unconditionally included the SSPI structure, preventing cntlm compiling on non-Cygwin platforms.

Make it conditional everywhere.  A consequence of this is that the `auth_s` structure is different on Cygwin and non-Cygwin platforms.
